### PR TITLE
backup user's tmux.conf instead of deleting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 install:
 	@if [ -f ~/.tmux.conf ]; \
 	then \
-		echo 'rm ~/.tmux.conf'; \
-		rm ~/.tmux.conf; \
+		echo 'mv ~/.tmux.conf ~/.tmux.conf.backup'; \
+		mv ~/.tmux.conf ~/.tmux.conf.backup; \
 	fi;
 	cp `pwd`/.tmux.conf ~/.tmux.conf
 	sed -i '' 's|{{pwd}}|'`pwd`'|g' ~/.tmux.conf
 
 uninstall:
-	rm ~/.tmux.conf
+	@if [ -f ~/.tmux.conf.backup ]; \
+	then \
+	mv ~/.tmux.conf.backup ~/.tmux.conf; \
+	fi


### PR DESCRIPTION
it's incredibly rude to just delete a user's config file, you should back it up first