### PR TITLE
add net to status_right, solves #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This plugin has the following optional dependencies:
 - [Tmux prefix highlight](https://github.com/tmux-plugins/tmux-prefix-highlight)
 - [Tmux Battery](https://github.com/tmux-plugins/tmux-battery)
 - [Tmux CPU](https://github.com/tmux-plugins/tmux-cpu)
+- [Tmux Net speed](https://github.com/tmux-plugins/tmux-net-speed)
 
 See [installing TPM plugins](https://github.com/tmux-plugins/tpm#installing-plugins).
 
@@ -57,6 +58,7 @@ set -g @tpm_plugins '                     \
     tmux-plugins/tmux-battery             \
     tmux-plugins/tmux-cpu                 \
     tmux-plugins/tmux-prefix-highlight    \
+    tmux-plugins/tmux-net-speed           \
 '
 
 # Initialize TMUX plugin manager

--- a/maglev.tmux
+++ b/maglev.tmux
@@ -11,7 +11,9 @@ fi
 SHOW_BATTERY=false
 if [[ $PLUGINS == *"tmux-battery"* ]]; then
     # if no battery can be found but the plugin is still enabled, this might result in some blank space in status-right
-    SHOW_BATTERY=true
+    if [ ! x"$(uname -s)" = x"Linux" ] || [[ "$(ls /sys/class/power_supply)" == *"BAT"* ]]; then
+        SHOW_BATTERY=true
+    fi
 fi
 SHOW_NET=false
 # net-speed plugin only works on linux as of yet (2018-03-24)

--- a/maglev.tmux
+++ b/maglev.tmux
@@ -3,17 +3,19 @@ set -e
 
 PLUGINS=$(tmux show-options -g | grep @tpm_plugins)
 
-# Determine whether the tmux-cpu plugin should be installed
+# Determine what plugins we can use
 SHOW_CPU=false
 if [[ $PLUGINS == *"tmux-cpu"* ]]; then
     SHOW_CPU=true
 fi
 SHOW_BATTERY=false
 if [[ $PLUGINS == *"tmux-battery"* ]]; then
+    # if no battery can be found but the plugin is still enabled, this might result in some blank space in status-right
     SHOW_BATTERY=true
 fi
 SHOW_NET=false
-if [[ $PLUGINS == *"tmux-net-speed"* ]]; then
+# net-speed plugin only works on linux as of yet (2018-03-24)
+if [[ $PLUGINS == *"tmux-net-speed"* ]] && [ x"$(uname -s)" = x"Linux" ]; then
     SHOW_NET=true
 fi
 

--- a/maglev.tmux
+++ b/maglev.tmux
@@ -12,6 +12,10 @@ SHOW_BATTERY=false
 if [[ $PLUGINS == *"tmux-battery"* ]]; then
     SHOW_BATTERY=true
 fi
+SHOW_NET=false
+if [[ $PLUGINS == *"tmux-net-speed"* ]]; then
+    SHOW_NET=true
+fi
 
 # Battery icons
 tmux set -g @batt_charged_icon "︎♡"
@@ -147,7 +151,7 @@ apply_theme() {
     status_right="︎#[fg=$time_date_fg,nobold]#{prefix_highlight} $right_separator %R $right_separator %a %d %b #[fg=$host_bg]"
 
     # Only show solid separator if CPU or Battery are to be displayed
-    if [ "$SHOW_BATTERY" = true ] || [ "$SHOW_CPU" = true ]; then
+    if [ "$SHOW_BATTERY" = true ] || [ "$SHOW_NET" = true ] || [ "$SHOW_CPU" = true ]; then
         status_right="$status_right $right_separator_black#[fg=$host_fg,bg=$host_bg,bold]"
     fi
 
@@ -155,8 +159,17 @@ apply_theme() {
         status_right="$status_right #{battery_icon} #{battery_percentage}"
     fi
 
-    # Only add intermediate separator if both CPU and Batter are to be displayed
-    if [ "$SHOW_BATTERY" = true ] && [ "$SHOW_CPU" = true ]; then
+    # Only add intermediate separator if both battery and network are to be displayed
+    if [ "$SHOW_BATTERY" = true ] && [ "$SHOW_NET" = true ]; then
+        status_right="$status_right $right_separator"
+    fi
+
+    if [ "$SHOW_NET" = true ]; then
+        status_right="$status_right  #{net_speed} "
+    fi
+
+    # Only add intermediate separator if both  and CPU are to be displayed
+    if ([ "$SHOW_BATTERY" = true ] || [ "$SHOW_NET" = true ]) && [ "$SHOW_CPU" = true ]; then
         status_right="$status_right $right_separator"
     fi
 
@@ -164,7 +177,7 @@ apply_theme() {
         status_right="$status_right CPU #{cpu_percentage} "
     fi
 
-    tmux set -g status-right-length 64 \; set -g status-right "$status_right"
+    tmux set -g status-right-length 80 \; set -g status-right "$status_right"
 
     # clock
     clock_mode_colour=colour4 # blue


### PR DESCRIPTION
uses unicode point f6ff (nf-mdi-ethernet) as defined by [nerdfonts](https://nerdfonts.com/#cheat-sheet)

todo(?): variate icon to indicate whether ethernet or wireless is connected