### PR TITLE
Add zoom indicator to status bar. Solves #28

### DIFF
--- a/maglev.tmux
+++ b/maglev.tmux
@@ -144,7 +144,7 @@ apply_theme() {
     whoami_bg=colour160         # red
     host_fg=colour16            # black
     host_bg=colour254           # white
-    status_right="︎#[fg=$time_date_fg,nobold]#{prefix_highlight} $right_separator %R $right_separator %a %d %b #[fg=$host_bg]"
+    status_right="︎#F#[fg=$time_date_fg,nobold]#{prefix_highlight} $right_separator %R $right_separator %a %d %b #[fg=$host_bg]"
 
     # Only show solid separator if CPU or Battery are to be displayed
     if [ "$SHOW_BATTERY" = true ] || [ "$SHOW_CPU" = true ]; then


### PR DESCRIPTION
Basically applied [this tmux powerline fix](https://github.com/powerline/powerline/pull/1436/commits/c687ea943fa8d925889d74228902b3ad31a7f2b6) to maglev. Could definitely be prettier, right now it adds a `*` in normal operation, which becomes `*Z`when zoomed.